### PR TITLE
Check that a parsed class is autoloadable

### DIFF
--- a/acme_src/ErrorConditions/BadNamespaceTest/MyTestCase.php
+++ b/acme_src/ErrorConditions/BadNamespaceTest/MyTestCase.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTest\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\Test;
+use Cspray\Labrador\AsyncUnit\TestCase;
+
+class MyTestCase extends TestCase {
+
+    #[Test]
+    public function checkSomething() : void {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestCaseAfterAll/MyTestCase.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestCaseAfterAll/MyTestCase.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestCaseAfterAll\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\AfterAll;
+use Cspray\Labrador\AsyncUnit\TestCase;
+
+class MyTestCase extends TestCase {
+
+    #[AfterAll]
+    public static function checkSomething() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestCaseAfterEach/MyTestCase.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestCaseAfterEach/MyTestCase.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestCaseAfterEach\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\AfterEach;
+use Cspray\Labrador\AsyncUnit\TestCase;
+
+class MyTestCase extends TestCase {
+
+    #[AfterEach]
+    public function afterEach() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestCaseBeforeAll/MyTestCase.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestCaseBeforeAll/MyTestCase.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestCaseBeforeAll\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\BeforeAll;
+use Cspray\Labrador\AsyncUnit\TestCase;
+
+class MyTestCase extends TestCase {
+
+    #[BeforeAll]
+    public static function checkBefore() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestCaseBeforeEach/MyTestCase.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestCaseBeforeEach/MyTestCase.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestCaseBeforeEach\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\BeforeEach;
+use Cspray\Labrador\AsyncUnit\TestCase;
+
+class MyTestCase extends TestCase {
+
+    #[BeforeEach]
+    public function checkEach() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestSuiteAfterAll/MyTestSuite.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestSuiteAfterAll/MyTestSuite.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestSuiteAfterAll\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\AfterAll;
+use Cspray\Labrador\AsyncUnit\TestSuite;
+
+class MyTestSuite extends TestSuite {
+
+    #[AfterAll]
+    public function checkAll() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestSuiteAfterEach/MyTestSuite.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestSuiteAfterEach/MyTestSuite.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestSuiteAfterEach\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\AfterEach;
+use Cspray\Labrador\AsyncUnit\TestSuite;
+
+class MyTestSuite extends TestSuite {
+
+    #[AfterEach]
+    public function checkEach() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestSuiteAfterEachTest/MyTestSuite.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestSuiteAfterEachTest/MyTestSuite.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestSuiteAfterEachTest\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\AfterEachTest;
+use Cspray\Labrador\AsyncUnit\TestSuite;
+
+class MyTestSuite extends TestSuite {
+
+    #[AfterEachTest]
+    public function checkEach() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestSuiteBeforeAll/MyTestSuite.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestSuiteBeforeAll/MyTestSuite.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestSuiteBeforeAll\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\BeforeAll;
+use Cspray\Labrador\AsyncUnit\TestSuite;
+
+class MyTestSuite extends TestSuite {
+
+    #[BeforeAll]
+    public function checkBefore() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestSuiteBeforeEach/MyTestSuite.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestSuiteBeforeEach/MyTestSuite.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestSuiteBeforeEach\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\BeforeEach;
+use Cspray\Labrador\AsyncUnit\TestSuite;
+
+class MyTestSuite extends TestSuite {
+
+    #[BeforeEach]
+    public function checkEach() {
+
+    }
+
+}

--- a/acme_src/ErrorConditions/BadNamespaceTestSuiteBeforeEachTest/MyTestSuite.php
+++ b/acme_src/ErrorConditions/BadNamespaceTestSuiteBeforeEachTest/MyTestSuite.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Acme\DemoSuites\ErrorConditions\BadNamespaceTestSuiteBeforeEachTest\IntentionallyBad;
+
+use Cspray\Labrador\AsyncUnit\Attribute\BeforeEachTest;
+use Cspray\Labrador\AsyncUnit\TestSuite;
+
+class MyTestSuite extends TestSuite {
+
+    #[BeforeEachTest]
+    public function checkEach() {
+
+    }
+
+}

--- a/framework_src/NodeVisitor/AsyncUnitVisitor.php
+++ b/framework_src/NodeVisitor/AsyncUnitVisitor.php
@@ -95,6 +95,14 @@ final class AsyncUnitVisitor extends NodeVisitorAbstract implements NodeVisitor 
         ];
         foreach ($validAttributes as $validAttribute => $validator) {
             if (!is_null($this->findAttribute($validAttribute, ...$classMethod->attrGroups))) {
+                $className = $classMethod->getAttribute('parent')->namespacedName->toString();
+                if (!class_exists($className)) {
+                    $msg = sprintf(
+                        'Failure compiling %s. The class cannot be autoloaded. Please ensure your Composer autoloader settings have been configured correctly',
+                        $className
+                    );
+                    throw new TestCompilationException($msg);
+                }
                 $validator();
                 return true;
             }

--- a/framework_test/ParserTest.php
+++ b/framework_test/ParserTest.php
@@ -7,6 +7,7 @@ use Cspray\Labrador\AsyncUnit\Model\PluginModel;
 use Cspray\Labrador\AsyncUnit\Model\TestCaseModel;
 use Cspray\Labrador\AsyncUnit\Model\TestModel;
 use Cspray\Labrador\AsyncUnit\Model\TestSuiteModel;
+use Acme\DemoSuites\ErrorConditions;
 use Acme\DemoSuites\ImplicitDefaultTestSuite;
 use Acme\DemoSuites\ExplicitTestSuite;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -78,6 +79,38 @@ class ParserTest extends PHPUnitTestCase {
         $this->expectException(TestCompilationException::class);
         $this->expectExceptionMessage('Failure compiling "Acme\\DemoSuites\\ErrorConditions\\BeforeEachAttributeOnNotTestCaseOrTestSuite\\BadTestCase". The method "ensureSomething" is annotated with #[BeforeEach] but this class does not extend "' . TestSuite::class . '" or "' . TestCase::class . '".');
         $this->subject->parse($this->acmeSrcDir . '/ErrorConditions/BeforeEachAttributeOnNotTestCaseOrTestSuite');
+    }
+
+    public function badNamespaceDataProvider() {
+        return [
+            ['BadNamespaceTest', 'MyTestCase'],
+            ['BadNamespaceTestCaseAfterAll', 'MyTestCase'],
+            ['BadNamespaceTestCaseAfterEach', 'MyTestCase'],
+            ['BadNamespaceTestCaseBeforeAll', 'MyTestCase'],
+            ['BadNamespaceTestCaseBeforeEach', 'MyTestCase'],
+            ['BadNamespaceTestSuiteAfterAll', 'MyTestSuite'],
+            ['BadNamespaceTestSuiteAfterEach', 'MyTestSuite'],
+            ['BadNamespaceTestSuiteAfterEachTest', 'MyTestSuite'],
+            ['BadNamespaceTestSuiteBeforeAll', 'MyTestSuite'],
+            ['BadNamespaceTestSuiteBeforeEach', 'MyTestSuite'],
+            ['BadNamespaceTestSuiteBeforeEachTest', 'MyTestSuite']
+        ];
+    }
+
+    /**
+     * @dataProvider badNamespaceDataProvider
+     */
+    public function testErrorConditionsBadNamespace(string $errorConditionNamespace, string $simpleClass) {
+        $this->expectException(TestCompilationException::class);
+        $expected = sprintf(
+            'Failure compiling Acme\\DemoSuites\\ErrorConditions\\%s\\IntentionallyBad\\%s. The class cannot be autoloaded. Please ensure your Composer autoloader settings have been configured correctly',
+            $errorConditionNamespace,
+            $simpleClass
+
+        );
+        $this->expectExceptionMessage($expected);
+
+        $this->subject->parse($this->acmeSrcDir . '/ErrorConditions/' . $errorConditionNamespace . '/');
     }
 
     public function testDefaultTestSuiteName() {


### PR DESCRIPTION
Ensures that a parsed class is autoloadable. Previously if a class that
has a method annotated with an AsyncUnit Attribute could not be loaded
the check for a subclass would fail and the error message would tell you
that you're annotating a method on a class that does not extend the
appropriate type when you were, in fact, extending the appropriate type.
The real problem is that the class extend the AsyncUnit TestCase could
not be autoloaded. This patch ensures that an appropriate error message
is shown stating that you need to setup your autoloader appropriately.